### PR TITLE
Ops: Add FIPS parameter for azure machine

### DIFF
--- a/api/v1beta1/azuremachine_types.go
+++ b/api/v1beta1/azuremachine_types.go
@@ -124,6 +124,10 @@ type AzureMachineSpec struct {
 	// +optional
 	SecurityProfile *SecurityProfile `json:"securityProfile,omitempty"`
 
+	// EnableFIPS allows the ability to use FIPS enabled virtual machines.
+	// +optional
+	EnableFIPS bool `json:"enableFIPS,omitempty"`
+
 	// Deprecated: SubnetName should be set in the networkInterfaces field.
 	// +optional
 	SubnetName string `json:"subnetName,omitempty"`

--- a/api/v1beta1/azuremachine_webhook.go
+++ b/api/v1beta1/azuremachine_webhook.go
@@ -165,6 +165,13 @@ func (mw *azureMachineWebhook) ValidateUpdate(ctx context.Context, oldObj, newOb
 	}
 
 	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "EnableFIPS"),
+		old.Spec.EnableFIPS,
+		m.Spec.EnableFIPS); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := webhookutils.ValidateImmutable(
 		field.NewPath("Spec", "SpotVMOptions"),
 		old.Spec.SpotVMOptions,
 		m.Spec.SpotVMOptions); err != nil {

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -725,6 +725,34 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "invalidTest: azuremachine.spec.EnableFIPS is immutable",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					EnableFIPS: true,
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					EnableFIPS: false,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "validTest: azuremachine.spec.EnableFIPS is immutable",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					EnableFIPS: true,
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					EnableFIPS: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "validTest: azuremachine.spec.Diagnostics should not error on updating nil diagnostics",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{},


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
- Addition of enableFips parameter for azure machine


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
   Add enableFips parameter for azure machine 
```
